### PR TITLE
Initial implementation to attach block handlers to an owner and remove on deinit

### DIFF
--- a/maps-app-ios/Maps App/App Notifications/BasemapNotifications.swift
+++ b/maps-app-ios/Maps App/App Notifications/BasemapNotifications.swift
@@ -16,13 +16,14 @@ import ArcGIS
 
 // MARK: External Notification API
 extension MapsAppNotifications {
-    static func observeBasemapChangedNotification(handler:@escaping ((AGSBasemap)->Void)) {
-        NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.CurrentBasemapChanged, object: mapsApp, queue: OperationQueue.main) { notification in
+    static func observeBasemapChangedNotification(owner:Any, handler:@escaping ((AGSBasemap)->Void)) {
+        let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.CurrentBasemapChanged, object: mapsApp, queue: OperationQueue.main) { notification in
             // The user selected a new basemap. Let's show it in the MapView.
             if let newBasemap = notification.basemap {
                 handler(newBasemap)
             }
         }
+        MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)
     }
 }
 

--- a/maps-app-ios/Maps App/App Notifications/CurrentItemNotifications.swift
+++ b/maps-app-ios/Maps App/App Notifications/CurrentItemNotifications.swift
@@ -16,16 +16,18 @@ import Foundation
 
 // MARK: External Notification API
 extension MapsAppNotifications {
-    static func observeCurrentItemChanged(handler:@escaping ()->Void) {
-        NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.CurrentItemChanged, object: mapsApp, queue: OperationQueue.main) { _ in
+    static func observeCurrentItemChanged(owner:Any, handler:@escaping ()->Void) {
+        let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.CurrentItemChanged, object: mapsApp, queue: OperationQueue.main) { _ in
             handler()
         }
+        MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)
     }
 
-    static func observeCurrentFolderChanged(handler:@escaping ()->Void) {
-        NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.CurrentFolderChanged, object: mapsApp, queue: OperationQueue.main) { _ in
+    static func observeCurrentFolderChanged(owner:Any, handler:@escaping ()->Void) {
+        let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.CurrentFolderChanged, object: mapsApp, queue: OperationQueue.main) { _ in
             handler()
         }
+        MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)
     }
 }
 

--- a/maps-app-ios/Maps App/App Notifications/LoginNotifications.swift
+++ b/maps-app-ios/Maps App/App Notifications/LoginNotifications.swift
@@ -17,19 +17,21 @@ import ArcGIS
 // MARK: External Notification API
 extension MapsAppNotifications {
     // MARK: Register Listeners
-    static func observeLoginStateNotifications(loginHandler:((AGSPortalUser)->Void)?, logoutHandler:(()->Void)?) {
+    static func observeLoginStateNotifications(owner:Any, loginHandler:((AGSPortalUser)->Void)?, logoutHandler:(()->Void)?) {
         if let loginHandler = loginHandler {
-            NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.AppLogin, object: mapsApp, queue: OperationQueue.main) { notification in
+            let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.AppLogin, object: mapsApp, queue: OperationQueue.main) { notification in
                 if let loggedInUser = notification.loggedInUser {
                     loginHandler(loggedInUser)
                 }
             }
+            MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)
         }
         
         if let logoutHandler = logoutHandler {
-            NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.AppLogout, object: mapsApp, queue: OperationQueue.main) { notification in
+            let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.AppLogout, object: mapsApp, queue: OperationQueue.main) { notification in
                 logoutHandler()
             }
+            MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)
         }
     }
 }

--- a/maps-app-ios/Maps App/App Notifications/MapsAppNotifications.swift
+++ b/maps-app-ios/Maps App/App Notifications/MapsAppNotifications.swift
@@ -13,9 +13,31 @@
 // limitations under the License.
 
 import Foundation
+import ObjectiveC
 
 // Intentionally blank structure. Additional Swift Files will extend this.
 struct MapsAppNotifications {
     struct Names {
+    }
+}
+
+extension MapsAppNotifications {
+    private struct AssociatedKeys {
+        static var notificationBlockReference = "notificationBlockReferences"
+    }
+
+    static internal func registerBlockHandler(blockHandler:NSObjectProtocol, forOwner owner:Any) {
+        var blockHandlers = (objc_getAssociatedObject(owner, &AssociatedKeys.notificationBlockReference) as? [NSObjectProtocol]) ?? []
+        blockHandlers.append(blockHandler)
+        objc_setAssociatedObject(owner, &AssociatedKeys.notificationBlockReference, blockHandlers, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    static func deregisterNotificationBlocks(forOwner owner:Any) {
+        if let blockHandlersForOwner = objc_getAssociatedObject(owner, &AssociatedKeys.notificationBlockReference) as? [NSObjectProtocol] {
+            for blockHandler in blockHandlersForOwner {
+                print("Removing observer block \(blockHandler) on owner \(owner)")
+                NotificationCenter.default.removeObserver(blockHandler)
+            }
+        }
     }
 }

--- a/maps-app-ios/Maps App/App Notifications/RouteNotifications.swift
+++ b/maps-app-ios/Maps App/App Notifications/RouteNotifications.swift
@@ -17,12 +17,13 @@ import ArcGIS
 // MARK: External Notification API
 extension MapsAppNotifications {
     // MARK: Register Listeners
-    static func observeRouteSolvedNotification(routeSolvedHandler: @escaping ((AGSRoute)->Void)) {
-        NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.RouteSolved, object: mapsApp, queue: OperationQueue.main) { notification in
+    static func observeRouteSolvedNotification(owner:Any, routeSolvedHandler: @escaping ((AGSRoute)->Void)) {
+        let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.RouteSolved, object: mapsApp, queue: OperationQueue.main) { notification in
             if let routeResult = notification.routeResult {
                 routeSolvedHandler(routeResult)
             }
         }
+        MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)
     }
 }
 

--- a/maps-app-ios/Maps App/App Notifications/SearchNotifications.swift
+++ b/maps-app-ios/Maps App/App Notifications/SearchNotifications.swift
@@ -17,15 +17,17 @@ import ArcGIS
 // MARK: External Notification API
 extension MapsAppNotifications {
     // MARK: Register Listeners
-    static func observeSearchNotifications(searchResultHandler:@escaping ((AGSGeocodeResult?)->Void), suggestionsAvailableHandler:(([AGSSuggestResult]?)->Void)? = nil) {
-        NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.SearchCompleted, object: mapsApp, queue: OperationQueue.main) { notification in
+    static func observeSearchNotifications(owner:Any, searchResultHandler:@escaping ((AGSGeocodeResult?)->Void), suggestionsAvailableHandler:(([AGSSuggestResult]?)->Void)? = nil) {
+        let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.SearchCompleted, object: mapsApp, queue: OperationQueue.main) { notification in
             searchResultHandler(notification.searchResult)
         }
+        MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)
         
         if let suggestionsAvailableHandler = suggestionsAvailableHandler {
-            NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.SearchSuggestionsAvailable, object: mapsApp, queue: OperationQueue.main) { notification in
+            let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.SearchSuggestionsAvailable, object: mapsApp, queue: OperationQueue.main) { notification in
                 suggestionsAvailableHandler(notification.searchSuggestions)
             }
+            MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)
         }
     }
 }

--- a/maps-app-ios/UI/Account View/AccountDetailsViewController.swift
+++ b/maps-app-ios/UI/Account View/AccountDetailsViewController.swift
@@ -37,13 +37,17 @@ class AccountDetailsViewController: UIViewController {
         setDisplayForLoginStatus()
     }
     
+    deinit {
+        MapsAppNotifications.deregisterNotificationBlocks(forOwner: self)
+    }
+    
     func setupLoginNotificationHandlers() {
-        MapsAppNotifications.observeLoginStateNotifications(loginHandler: { _ in self.setDisplayForLoginStatus() },
+        MapsAppNotifications.observeLoginStateNotifications(owner: self, loginHandler: { _ in self.setDisplayForLoginStatus() },
                                                             logoutHandler: { self.setDisplayForLoginStatus() })
     }
     
     func setupFolderChangeNotificationHandlers() {
-        MapsAppNotifications.observeCurrentFolderChanged() { self.showContent() }
+        MapsAppNotifications.observeCurrentFolderChanged(owner: self) { self.showContent() }
     }
     
     func setDisplayForLoginStatus() {

--- a/maps-app-ios/UI/Account View/AccountViewController.swift
+++ b/maps-app-ios/UI/Account View/AccountViewController.swift
@@ -26,13 +26,19 @@ class AccountViewController: UIViewController {
         setupLoginNotificationHandlers()
     }
     
+
+    deinit {
+        MapsAppNotifications.deregisterNotificationBlocks(forOwner: self)
+    }
+
+    
     func showAccountPanelForLoginStatus() {
         loggedOutContainer.isHidden = mapsAppContext.isLoggedIn
         loggedInContainer.isHidden = !loggedOutContainer.isHidden
     }
     
     func setupLoginNotificationHandlers() {
-        MapsAppNotifications.observeLoginStateNotifications(loginHandler: { _ in self.showAccountPanelForLoginStatus() },
+        MapsAppNotifications.observeLoginStateNotifications(owner: self, loginHandler: { _ in self.showAccountPanelForLoginStatus() },
                                                             logoutHandler: { _ in self.showAccountPanelForLoginStatus() })
     }
 

--- a/maps-app-ios/UI/Feedback View/Feedback Panels/RouteResultViewController.swift
+++ b/maps-app-ios/UI/Feedback View/Feedback Panels/RouteResultViewController.swift
@@ -45,11 +45,15 @@ class RouteResultViewController : UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        MapsAppNotifications.observeRouteSolvedNotification { route in
+        MapsAppNotifications.observeRouteSolvedNotification(owner: self) { route in
             self.routeResult = route
         }
     }
     
+    deinit {
+        MapsAppNotifications.deregisterNotificationBlocks(forOwner: self)
+    }
+
     @IBAction func summaryTapped(_ sender: Any) {
         MapsAppNotifications.postMapViewResetExtentForModeNotification()
     }

--- a/maps-app-ios/UI/Feedback View/FeedbackViewController+FeedbackMode.swift
+++ b/maps-app-ios/UI/Feedback View/FeedbackViewController+FeedbackMode.swift
@@ -25,7 +25,7 @@ extension FeedbackViewController {
     }
     
     func setupModeChangeListener() {
-        MapsAppNotifications.observeModeChangeNotification { oldValue, newValue in
+        MapsAppNotifications.observeModeChangeNotification(owner: self) { oldValue, newValue in
             self.setUIForMode(mode: newValue, previousMode: oldValue)
         }
     }

--- a/maps-app-ios/UI/Feedback View/FeedbackViewController.swift
+++ b/maps-app-ios/UI/Feedback View/FeedbackViewController.swift
@@ -28,4 +28,8 @@ class FeedbackViewController : UIViewController {
     @IBAction func returnToSearch(_ segue:UIStoryboardSegue) {
         self.mode = .search
     }
+    
+    deinit {
+        MapsAppNotifications.deregisterNotificationBlocks(forOwner: self)
+    }
 }

--- a/maps-app-ios/UI/Map View/MapViewController+AppState/MapViewController+Basemap.swift
+++ b/maps-app-ios/UI/Map View/MapViewController+AppState/MapViewController+Basemap.swift
@@ -16,7 +16,7 @@ import ArcGIS
 
 extension MapViewController {
     func setupBasemapChangeHandler() {
-        MapsAppNotifications.observeBasemapChangedNotification { newBasemap in
+        MapsAppNotifications.observeBasemapChangedNotification(owner: self) { newBasemap in
             self.mapView.map?.basemap = newBasemap
             
             newBasemap.load(){ error in

--- a/maps-app-ios/UI/Map View/MapViewController+AppState/MapViewController+CurrentItem.swift
+++ b/maps-app-ios/UI/Map View/MapViewController+AppState/MapViewController+CurrentItem.swift
@@ -18,7 +18,7 @@ fileprivate let fallbackWebMapVersionErrorMessage = "The WebMap version is pre 2
 
 extension MapViewController {
     func setupCurrentItemChangeHandler() {
-        MapsAppNotifications.observeCurrentItemChanged() {
+        MapsAppNotifications.observeCurrentItemChanged(owner: self) {
             // The app's current item has changed. Let's show the new item in the MapView.
             self.displayCurrentItem()
         }

--- a/maps-app-ios/UI/Map View/MapViewController+Routing/MapViewController+RoutingSetup.swift
+++ b/maps-app-ios/UI/Map View/MapViewController+Routing/MapViewController+RoutingSetup.swift
@@ -18,7 +18,7 @@ extension MapViewController {
     func setupRouting() {
         self.mapView.graphicsOverlays.add(self.routeResultsOverlay)
 
-        MapsAppNotifications.observeRouteSolvedNotification { result in
+        MapsAppNotifications.observeRouteSolvedNotification(owner: self) { result in
             self.mode = .routeResult(result)
         }
 

--- a/maps-app-ios/UI/Map View/MapViewController+Search/MapViewController+SearchSetup.swift
+++ b/maps-app-ios/UI/Map View/MapViewController+Search/MapViewController+SearchSetup.swift
@@ -19,7 +19,7 @@ extension MapViewController {
         // Add a layer to the map to display search results
         mapView.graphicsOverlays.add(geocodeResultsOverlay)
         
-        MapsAppNotifications.observeSearchNotifications(searchResultHandler: { result in
+        MapsAppNotifications.observeSearchNotifications(owner: self, searchResultHandler: { result in
             if let result = result {
                 self.mode = .geocodeResult(result)
             }

--- a/maps-app-ios/UI/Map View/MapViewController.swift
+++ b/maps-app-ios/UI/Map View/MapViewController.swift
@@ -120,6 +120,10 @@ class MapViewController: UIViewController {
         mode = .search
     }
     
+    deinit {
+        MapsAppNotifications.deregisterNotificationBlocks(forOwner: self)
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 

--- a/maps-app-ios/UI/Map View/MapViewMode/MapViewModeNotifications.swift
+++ b/maps-app-ios/UI/Map View/MapViewMode/MapViewModeNotifications.swift
@@ -19,12 +19,13 @@ extension MapsAppNotifications.Names {
 }
 
 extension MapsAppNotifications {
-    static func observeModeChangeNotification(modeChangeHandler:@escaping (MapViewMode,MapViewMode)->Void) {
-        NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.MapViewModeChanged, object: nil, queue: OperationQueue.main) { notification in
+    static func observeModeChangeNotification(owner:Any, modeChangeHandler:@escaping (MapViewMode,MapViewMode)->Void) {
+        let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.MapViewModeChanged, object: nil, queue: OperationQueue.main) { notification in
             if let newValue = notification.newMapViewMode, let oldValue = notification.oldMapViewMode {
                 modeChangeHandler(oldValue, newValue)
             }
         }
+        MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)
     }
     
     static func postModeChangeNotification(oldMode:MapViewMode, newMode:MapViewMode) {

--- a/maps-app-ios/UI/Suggestions View/SuggestionDisplayViewController.swift
+++ b/maps-app-ios/UI/Suggestions View/SuggestionDisplayViewController.swift
@@ -55,11 +55,15 @@ class SuggestionDisplayViewController: UIViewController, UITableViewDataSource, 
         
         suggestions = nil
         
-        MapsAppNotifications.observeSearchNotifications(searchResultHandler: { _ in
+        MapsAppNotifications.observeSearchNotifications(owner: self, searchResultHandler: { _ in
             self.suggestions = nil
         }, suggestionsAvailableHandler: { suggestions in
             self.suggestions = suggestions
         })        
+    }
+    
+    deinit {
+        MapsAppNotifications.deregisterNotificationBlocks(forOwner: self)
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Have updated `observeXYZNotification` methods to take an initial `owner` parameter.

I use Objective-C Associated Objects to keep an array of `NSObjectProtocol` instances associated with the `owner`.

In the owner's `deinit`, they should call:

``` swift
MapsAppNotifications.deregisterNotificationBlocks(forOwner: self)
```

Problem is that I can't get a `deinit` to happen.

Interestingly, each time I segue in the `AccountViewController` by tapping on the bottom-right icon, `viewDidLoad()` is called on a new instance of `AccountViewController`, but I don't see any sign that `deinit` is ever called on the old instance.

That is:

1. Open app.
2. Tap on account view button. See notification observers being added as expected from the `AccountViewController.viewDidLoad()`.
3. Close the account view.
4. Tap on account view button again. See notification observers being added on a new instance of `AccountViewController` during `viewDidLoad()`. What happened to the instance from step 2??
5. Be confused.

Any thoughts?