### PR TITLE
use weak self; remove PortalUser argument

### DIFF
--- a/maps-app-ios/Maps App/App Notifications/LoginNotifications.swift
+++ b/maps-app-ios/Maps App/App Notifications/LoginNotifications.swift
@@ -17,11 +17,11 @@ import ArcGIS
 // MARK: External Notification API
 extension MapsAppNotifications {
     // MARK: Register Listeners
-    static func observeLoginStateNotifications(owner:Any, loginHandler:((AGSPortalUser)->Void)?, logoutHandler:(()->Void)?) {
+    static func observeLoginStateNotifications(owner:Any, loginHandler:(()->Void)?, logoutHandler:(()->Void)?) {
         if let loginHandler = loginHandler {
             let ref = NotificationCenter.default.addObserver(forName: MapsAppNotifications.Names.AppLogin, object: mapsApp, queue: OperationQueue.main) { notification in
-                if let loggedInUser = notification.loggedInUser {
-                    loginHandler(loggedInUser)
+                if let _ = notification.loggedInUser {
+                    loginHandler()
                 }
             }
             MapsAppNotifications.registerBlockHandler(blockHandler: ref, forOwner: owner)

--- a/maps-app-ios/UI/Account View/AccountDetailsViewController.swift
+++ b/maps-app-ios/UI/Account View/AccountDetailsViewController.swift
@@ -42,12 +42,12 @@ class AccountDetailsViewController: UIViewController {
     }
     
     func setupLoginNotificationHandlers() {
-        MapsAppNotifications.observeLoginStateNotifications(owner: self, loginHandler: { _ in self.setDisplayForLoginStatus() },
-                                                            logoutHandler: { self.setDisplayForLoginStatus() })
+        MapsAppNotifications.observeLoginStateNotifications(owner: self, loginHandler: { [weak self] () in self?.setDisplayForLoginStatus() },
+                                                            logoutHandler: { [weak self] () in self?.setDisplayForLoginStatus() })
     }
     
     func setupFolderChangeNotificationHandlers() {
-        MapsAppNotifications.observeCurrentFolderChanged(owner: self) { self.showContent() }
+        MapsAppNotifications.observeCurrentFolderChanged(owner: self) { [weak self] () in self?.showContent() }
     }
     
     func setDisplayForLoginStatus() {

--- a/maps-app-ios/UI/Account View/AccountViewController.swift
+++ b/maps-app-ios/UI/Account View/AccountViewController.swift
@@ -38,8 +38,8 @@ class AccountViewController: UIViewController {
     }
     
     func setupLoginNotificationHandlers() {
-        MapsAppNotifications.observeLoginStateNotifications(owner: self, loginHandler: { _ in self.showAccountPanelForLoginStatus() },
-                                                            logoutHandler: { _ in self.showAccountPanelForLoginStatus() })
+        MapsAppNotifications.observeLoginStateNotifications(owner: self, loginHandler: { [weak self] () in self?.showAccountPanelForLoginStatus() },
+                                                            logoutHandler: { [weak self] () in self?.showAccountPanelForLoginStatus() })
     }
 
     @IBAction func closeAccountViewer(_: UIStoryboardSegue) {


### PR DESCRIPTION
The reason the `deinit()` wasn't getting called was the notification blocks were holding onto `self`, which prevented it from being released.  I made the changes to use `[weak self]` and then I did get the `deinit()` call.

I also made a little change to remove the `AGSPortalUser` argument from the `loginHandler`, since it was never being used.