### PR TITLE
Migrates to Swift 4.2

### DIFF
--- a/maps-app-ios.xcodeproj/project.pbxproj
+++ b/maps-app-ios.xcodeproj/project.pbxproj
@@ -720,20 +720,20 @@
 				TargetAttributes = {
 					D96A77501E8594BF00F441D3 = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 0940;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Manual;
 					};
 					D96A77641E8594C000F441D3 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = J8UEUYLV27;
-						LastSwiftMigration = 0940;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 						TestTargetID = D96A77501E8594BF00F441D3;
 					};
 					D96A776F1E8594C000F441D3 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = J8UEUYLV27;
-						LastSwiftMigration = 0940;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 						TestTargetID = D96A77501E8594BF00F441D3;
 					};
@@ -1078,8 +1078,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "maps-app-ios/3rd Party/maps-app-ios-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
@@ -1107,8 +1106,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "maps-app-ios/3rd Party/maps-app-ios-Bridging-Header.h";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
@@ -1123,8 +1121,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.example-apps.maps-app-iosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/maps-app-ios.app/maps-app-ios";
 			};
 			name = Debug;
@@ -1139,8 +1136,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.example-apps.maps-app-iosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/maps-app-ios.app/maps-app-ios";
 			};
 			name = Release;
@@ -1154,8 +1150,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.example-apps.maps-app-iosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = "maps-app-ios";
 			};
 			name = Debug;
@@ -1169,8 +1164,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.example-apps.maps-app-iosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = "maps-app-ios";
 			};
 			name = Release;

--- a/maps-app-ios/Extensions/UIViewAnimationCurve+UIViewAnimationOptions.swift
+++ b/maps-app-ios/Extensions/UIViewAnimationCurve+UIViewAnimationOptions.swift
@@ -14,17 +14,17 @@
 
 import UIKit
 
-extension UIViewAnimationCurve {
-    var correspondingAnimationOption:UIViewAnimationOptions {
+extension UIView.AnimationCurve {
+    var correspondingAnimationOption:UIView.AnimationOptions {
         switch self {
         case .linear:
-            return UIViewAnimationOptions.curveLinear
+            return UIView.AnimationOptions.curveLinear
         case .easeIn:
-            return UIViewAnimationOptions.curveEaseIn
+            return UIView.AnimationOptions.curveEaseIn
         case .easeOut:
-            return UIViewAnimationOptions.curveEaseOut
+            return UIView.AnimationOptions.curveEaseOut
         case .easeInOut:
-            return UIViewAnimationOptions.curveEaseInOut
+            return UIView.AnimationOptions.curveEaseInOut
         }
     }
 }

--- a/maps-app-ios/Maps App/Maps App Delegate/MapsAppDelegate+AppStartup.swift
+++ b/maps-app-ios/Maps App/Maps App Delegate/MapsAppDelegate+AppStartup.swift
@@ -17,7 +17,7 @@ import ArcGIS
 extension MapsAppDelegate {
     
     // MARK: App start
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // License the runtime
         do {
             try AGSArcGISRuntimeEnvironment.setLicenseKey(AppSettings.licenseKey)

--- a/maps-app-ios/Maps App/Maps App Delegate/MapsAppDelegate+OAuthLogin.swift
+++ b/maps-app-ios/Maps App/Maps App Delegate/MapsAppDelegate+OAuthLogin.swift
@@ -17,7 +17,7 @@ import ArcGIS
 extension MapsAppDelegate {
     
     // MARK: OAuth
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         // Handle OAuth callback from application(app,url,options) when the app's URL schema is called.
         //
         // See also AppSettings and AppContext.setupAndLoadPortal() to see how the AGSPortal is configured

--- a/maps-app-ios/UI/Account View/AccountLoginViewController.swift
+++ b/maps-app-ios/UI/Account View/AccountLoginViewController.swift
@@ -23,6 +23,11 @@ class AccountLoginViewController: UIViewController {
     }
     
     @IBAction func signUp(_ sender: Any) {
-        UIApplication.shared.open(signUpURL, options: [:], completionHandler: nil)
+        UIApplication.shared.open(signUpURL, options: convertToUIApplicationOpenExternalURLOptionsKeyDictionary([:]), completionHandler: nil)
     }
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertToUIApplicationOpenExternalURLOptionsKeyDictionary(_ input: [String: Any]) -> [UIApplication.OpenExternalURLOptionsKey: Any] {
+	return Dictionary(uniqueKeysWithValues: input.map { key, value in (UIApplication.OpenExternalURLOptionsKey(rawValue: key), value)})
 }

--- a/maps-app-ios/UI/Account View/PortalUserFolder.swift
+++ b/maps-app-ios/UI/Account View/PortalUserFolder.swift
@@ -75,7 +75,7 @@ class PortalUserFolder: AGSLoadableBase {
     }
     
     // MARK: Hashable
-    override var hashValue: Int {
+    override var hash: Int {
         return containerType.hashValue
     }
     

--- a/maps-app-ios/UI/Directions View/DirectionsDisplayViewController.swift
+++ b/maps-app-ios/UI/Directions View/DirectionsDisplayViewController.swift
@@ -52,7 +52,7 @@ class DirectionsDisplayViewController: UIViewController, UICollectionViewDataSou
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        maneuversView.decelerationRate = UIScrollViewDecelerationRateNormal
+        maneuversView.decelerationRate = UIScrollView.DecelerationRate.normal
         
         view.translatesAutoresizingMaskIntoConstraints = false
         
@@ -121,7 +121,7 @@ class DirectionsDisplayViewController: UIViewController, UICollectionViewDataSou
             
             // If we have a current cell, make sure it's displayed.
             if let cellIndex = self.currentCellIndex {
-                self.maneuversView.scrollToItem(at: cellIndex, at: UICollectionViewScrollPosition.centeredHorizontally, animated: false)
+                self.maneuversView.scrollToItem(at: cellIndex, at: UICollectionView.ScrollPosition.centeredHorizontally, animated: false)
             }
         }
     }

--- a/maps-app-ios/UI/Feedback View/FeedbackContentsSegue.swift
+++ b/maps-app-ios/UI/Feedback View/FeedbackContentsSegue.swift
@@ -19,7 +19,7 @@ class FeedbackContentsSegue: UIStoryboardSegue {
     var feedbackViewController:FeedbackViewController!
     
     override func perform() {
-        let from = feedbackViewController.childViewControllers.first
+        let from = feedbackViewController.children.first
         let to = self.destination
         swapChildVCs(from: from, to: to)
     }
@@ -45,24 +45,24 @@ class FeedbackContentsSegue: UIStoryboardSegue {
         
         guard let from = from else {
             // First time we're installing a contained view controller, just add it, don't transition to it.
-            feedbackViewController.addChildViewController(to)
+            feedbackViewController.addChild(to)
             feedbackViewController.containerView.addSubview(to.view)
-            to.didMove(toParentViewController: feedbackViewController)
+            to.didMove(toParent: feedbackViewController)
             
             return
         }
         
         // Switch from one view controller to another.
-        from.willMove(toParentViewController: nil)
-        feedbackViewController.addChildViewController(to)
+        from.willMove(toParent: nil)
+        feedbackViewController.addChild(to)
         
         // If duration > 0, this can crash if the user double-taps quickly on redo/undo. Need to ensure that
         // transitions are enqueued before animation can be reintroduced.
         feedbackViewController.transition(from: from, to: to, duration: 0, options: .transitionCrossDissolve, animations: nil) { finished in
             // After we've moved, complete our contract to the viewcontrollers so, and notify the MapsApp, since we might
             // be a different size than before and the MapView can consider that when zooming to a geometry.
-            from.removeFromParentViewController()
-            to.didMove(toParentViewController: self.feedbackViewController)
+            from.removeFromParent()
+            to.didMove(toParent: self.feedbackViewController)
             
             MapsAppNotifications.postFeedbackPanelResizedNotification(panel: self.feedbackViewController)
         }

--- a/maps-app-ios/UI/Feedback View/FeedbackViewController+RelatedViewControllers.swift
+++ b/maps-app-ios/UI/Feedback View/FeedbackViewController+RelatedViewControllers.swift
@@ -20,10 +20,10 @@ extension FeedbackViewController {
     }
     
     var geocodeResultViewController:GeocodeResultViewController? {
-        return self.childViewControllers.filter({ $0 is GeocodeResultViewController }).first as? GeocodeResultViewController
+        return self.children.filter({ $0 is GeocodeResultViewController }).first as? GeocodeResultViewController
     }
     
     var routeResultViewController:RouteResultViewController? {
-        return self.childViewControllers.filter({ $0 is RouteResultViewController }).first as? RouteResultViewController
+        return self.children.filter({ $0 is RouteResultViewController }).first as? RouteResultViewController
     }    
 }

--- a/maps-app-ios/UI/Map View/MapViewController+FeedbackPanel.swift
+++ b/maps-app-ios/UI/Map View/MapViewController+FeedbackPanel.swift
@@ -29,6 +29,6 @@ extension MapViewController {
     }
     
     var feedbackViewController:FeedbackViewController? {
-        return self.childViewControllers.filter({ $0 is FeedbackViewController }).first as? FeedbackViewController
+        return self.children.filter({ $0 is FeedbackViewController }).first as? FeedbackViewController
     }
 }

--- a/maps-app-ios/UI/Map View/MapViewController+KeyboardTracking.swift
+++ b/maps-app-ios/UI/Map View/MapViewController+KeyboardTracking.swift
@@ -29,7 +29,7 @@ extension MapViewController {
     
     func activateKeyboardTracking() {
         // Listen to keyboard notifications.
-        for notificationName:Notification.Name in [.UIKeyboardWillShow, .UIKeyboardWillHide] {
+        for notificationName:Notification.Name in [UIResponder.keyboardWillShowNotification, UIResponder.keyboardWillHideNotification] {
             keyboardObservers.append(NotificationCenter.default.addObserver(forName: notificationName, object: nil, queue: nil) { notification in
                 // Set our special view that tracks the keyboard. Either display or hide.
                 self.setKeyboardSpacerFromKeyboardNotification(notification: notification)
@@ -52,17 +52,17 @@ extension MapViewController {
         // to avoid being hidden by the keyboard.
         // Derived from code found at https://stackoverflow.com/questions/8704137/keeping-object-on-top-of-keyboard-in-the-event-of-becomefirstresponder-or-resign
         if let userInfo = notification.userInfo,
-            let duration = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue,
-            let endFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            let duration = (userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue,
+            let endFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             
             let endFrameInContext = view.convert(endFrame, to: self.view)
             let newHeight = view.bounds.maxY - endFrameInContext.minY
             
             UIView.animate(withDuration: duration) {
-                if notification.name == .UIKeyboardWillShow {
+                if notification.name == UIResponder.keyboardWillShowNotification {
                     self.attributeAnchor?.isActive = false
                     self.keyboardAnchor?.isActive = true
-                } else if notification.name == .UIKeyboardWillHide {
+                } else if notification.name == UIResponder.keyboardWillHideNotification {
                     self.attributeAnchor?.isActive = true
                     self.keyboardAnchor?.isActive = false
                 }

--- a/maps-app-ios/UI/Map View/MapViewController+MapViewModeHistory.swift
+++ b/maps-app-ios/UI/Map View/MapViewController+MapViewModeHistory.swift
@@ -71,7 +71,7 @@ extension MapViewController {
     }
 
     // MARK: Shake to "undo" mode change.
-    override func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?) {
+    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         guard hasPreviousMode || hasNextMode else {
             return
         }
@@ -99,7 +99,7 @@ extension MapViewController {
             prevNextAlertController.addAction(nextAction)
         }
         
-        let cancelAction = UIAlertAction(title: "Cancel", style: UIAlertActionStyle.cancel, handler: { _ in
+        let cancelAction = UIAlertAction(title: "Cancel", style: UIAlertAction.Style.cancel, handler: { _ in
             prevNextAlertController.dismiss(animated: true, completion: nil)
         })
         prevNextAlertController.addAction(cancelAction)

--- a/maps-app-ios/UI/Map View/MapViewMode/MapViewMode+ResultsDisplay.swift
+++ b/maps-app-ios/UI/Map View/MapViewMode/MapViewMode+ResultsDisplay.swift
@@ -94,7 +94,7 @@ extension MapViewMode {
     }
 
     private func envelopeForGraphics(graphics:[AGSGraphic], expansionFactor:Double = 1) -> AGSEnvelope? {
-        let geoms = graphics.flatMap({ graphic -> AGSGeometry? in
+        let geoms = graphics.compactMap({ graphic -> AGSGeometry? in
             return graphic.geometry
         })
         if let builder = geoms.first?.extent.toBuilder() {


### PR DESCRIPTION
Following these steps:
1. Use Swift migration assistant.
2. Updates where Swift compiler warnings.

@nixta might there be other areas of the app you would recommend migrating more actively?