### PR TITLE
iOS-version specific searchbar constraints control

### DIFF
--- a/maps-app-ios/UI/Feedback View/Feedback Panels/SearchViewController.swift
+++ b/maps-app-ios/UI/Feedback View/Feedback Panels/SearchViewController.swift
@@ -18,6 +18,15 @@ class SearchViewController : UIViewController, UISearchBarDelegate {
     
     @IBOutlet weak var searchBar: UISearchBar!
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        guard #available(iOS 11, *) else {
+            searchBar.constraints.filter({ $0.identifier == "ios11SearchbarHeight" }).first?.isActive = false
+            return
+        }
+    }
+    
     lazy var suggestDebouncer:Debouncer = {
         let debouncer = Debouncer(delay: 0.1) {
             defer {

--- a/maps-app-ios/UI/Feedback View/Feedback Panels/SearchViewController.swift
+++ b/maps-app-ios/UI/Feedback View/Feedback Panels/SearchViewController.swift
@@ -18,15 +18,6 @@ class SearchViewController : UIViewController, UISearchBarDelegate {
     
     @IBOutlet weak var searchBar: UISearchBar!
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        guard #available(iOS 11, *) else {
-            searchBar.constraints.filter({ $0.identifier == "ios11SearchbarHeight" }).first?.isActive = false
-            return
-        }
-    }
-    
     lazy var suggestDebouncer:Debouncer = {
         let debouncer = Debouncer(delay: 0.1) {
             defer {

--- a/maps-app-ios/UI/Feedback View/Feedback.storyboard
+++ b/maps-app-ios/UI/Feedback View/Feedback.storyboard
@@ -70,12 +70,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="Address or Place" translatesAutoresizingMaskIntoConstraints="NO" id="O7t-Dj-Ug0">
+                            <searchBar contentMode="redraw" verticalCompressionResistancePriority="1000" searchBarStyle="minimal" placeholder="Address or Place" translatesAutoresizingMaskIntoConstraints="NO" id="O7t-Dj-Ug0">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" identifier="ios10SearchbarHeight" id="QbO-WJ-dQW"/>
-                                    <constraint firstAttribute="height" priority="999" constant="56" identifier="ios11SearchbarHeight" id="SmJ-u4-nHc"/>
-                                </constraints>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="search" enablesReturnKeyAutomatically="YES" textContentType="location"/>
                                 <connections>
                                     <outlet property="delegate" destination="Wma-xI-VYV" id="ZlC-BY-yvZ"/>

--- a/maps-app-ios/UI/Feedback View/Feedback.storyboard
+++ b/maps-app-ios/UI/Feedback View/Feedback.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Rev-Z6-RLx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Rev-Z6-RLx">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -29,7 +27,7 @@
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="shadow" value="YES"/>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                        <real key="value" value="10"/>
+                                        <real key="value" value="12"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                                         <real key="value" value="0.0"/>
@@ -69,13 +67,13 @@
                         <viewControllerLayoutGuide type="bottom" id="1vd-TK-4RB"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="OkP-Fc-GQU">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="Address or Place" translatesAutoresizingMaskIntoConstraints="NO" id="O7t-Dj-Ug0">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="wvN-YM-V1y"/>
+                                    <constraint firstAttribute="height" constant="56" id="SmJ-u4-nHc"/>
                                 </constraints>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="search" enablesReturnKeyAutomatically="YES" textContentType="location"/>
                                 <connections>
@@ -84,12 +82,13 @@
                             </searchBar>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="O7t-Dj-Ug0" firstAttribute="top" secondItem="EA4-Qf-zbq" secondAttribute="bottom" id="54O-6f-WOS"/>
-                            <constraint firstItem="O7t-Dj-Ug0" firstAttribute="leading" secondItem="OkP-Fc-GQU" secondAttribute="leading" id="6tU-wf-4hq"/>
-                            <constraint firstAttribute="trailing" secondItem="O7t-Dj-Ug0" secondAttribute="trailing" priority="999" id="r83-du-UvL"/>
+                            <constraint firstItem="1vd-TK-4RB" firstAttribute="top" secondItem="O7t-Dj-Ug0" secondAttribute="bottom" id="G32-kt-cp2"/>
+                            <constraint firstAttribute="trailing" secondItem="O7t-Dj-Ug0" secondAttribute="trailing" id="e5D-ie-vBr"/>
+                            <constraint firstItem="O7t-Dj-Ug0" firstAttribute="leading" secondItem="OkP-Fc-GQU" secondAttribute="leading" id="iGB-21-0cr"/>
+                            <constraint firstItem="O7t-Dj-Ug0" firstAttribute="top" secondItem="EA4-Qf-zbq" secondAttribute="bottom" id="uhN-Qh-Pju"/>
                         </constraints>
                     </view>
-                    <size key="freeformSize" width="375" height="44"/>
+                    <size key="freeformSize" width="375" height="56"/>
                     <connections>
                         <outlet property="searchBar" destination="O7t-Dj-Ug0" id="gyv-uY-u7u"/>
                     </connections>
@@ -114,25 +113,25 @@
                                 <rect key="frame" x="8" y="4" width="359" height="72"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="800" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="OVz-Lr-93O">
-                                        <rect key="frame" x="0.0" y="0.0" width="319" height="72"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="287" height="72"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mWP-PU-2o4" userLabel="From Stack">
-                                                <rect key="frame" x="0.0" y="0.0" width="319" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="287" height="20"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="From:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R17-ha-Wxz">
-                                                        <rect key="frame" x="0.0" y="0.0" width="44" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="44" height="20"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2aD-ce-Bpq">
-                                                        <rect key="frame" x="52" y="0.0" width="239" height="20.5"/>
+                                                        <rect key="frame" x="52" y="0.0" width="207" height="20"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Route Start" translatesAutoresizingMaskIntoConstraints="NO" id="Fjg-Vp-IXf">
-                                                        <rect key="frame" x="299" y="0.0" width="20" height="20"/>
+                                                        <rect key="frame" x="267" y="0.0" width="20" height="20"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="Fjg-Vp-IXf" secondAttribute="height" multiplier="1:1" id="3n5-O8-EOv"/>
                                                             <constraint firstAttribute="height" constant="20" id="tJf-EW-R9G"/>
@@ -144,7 +143,7 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="98Z-Gd-voJ" userLabel="To Stack">
-                                                <rect key="frame" x="0.0" y="24.5" width="319" height="20"/>
+                                                <rect key="frame" x="0.0" y="24" width="287" height="20"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7gH-zT-q5G" userLabel="To:">
                                                         <rect key="frame" x="0.0" y="0.0" width="44" height="20"/>
@@ -153,13 +152,13 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="9" adjustsLetterSpacingToFitWidth="YES" preferredMaxLayoutWidth="185" translatesAutoresizingMaskIntoConstraints="NO" id="m9f-aR-4NK">
-                                                        <rect key="frame" x="52" y="0.0" width="239" height="20"/>
+                                                        <rect key="frame" x="52" y="0.0" width="207" height="20"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Route End" translatesAutoresizingMaskIntoConstraints="NO" id="Edq-kO-ZEx">
-                                                        <rect key="frame" x="299" y="0.0" width="20" height="20"/>
+                                                        <rect key="frame" x="267" y="0.0" width="20" height="20"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="20" id="4hN-hv-biu"/>
                                                             <constraint firstAttribute="width" secondItem="Edq-kO-ZEx" secondAttribute="height" multiplier="1:1" id="syi-gK-eXa"/>
@@ -172,13 +171,13 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="5Mb-pW-rE6" userLabel="Summary Stack">
-                                                <rect key="frame" x="0.0" y="48.5" width="319" height="23.5"/>
+                                                <rect key="frame" x="0.0" y="48" width="287" height="24"/>
                                                 <subviews>
                                                     <view userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Hk-tN-jaw">
-                                                        <rect key="frame" x="0.0" y="0.0" width="44" height="23.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="44" height="24"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Sedan" translatesAutoresizingMaskIntoConstraints="NO" id="l7o-Rc-omC">
-                                                                <rect key="frame" x="20" y="0.0" width="24" height="24"/>
+                                                                <rect key="frame" x="20" y="-12" width="24" height="48"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="24" id="zpn-Yz-xQH"/>
                                                                 </constraints>
@@ -190,7 +189,7 @@
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="SgX-GL-sei">
-                                                        <rect key="frame" x="52" y="0.0" width="267" height="23.5"/>
+                                                        <rect key="frame" x="52" y="0.0" width="235" height="24"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -215,7 +214,7 @@
                                         </constraints>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aFe-Ln-wqg" userLabel="Close Button">
-                                        <rect key="frame" x="327" y="0.0" width="32" height="72"/>
+                                        <rect key="frame" x="295" y="0.0" width="64" height="72"/>
                                         <state key="normal" image="Cancel"/>
                                         <connections>
                                             <segue destination="hwd-Cr-ngo" kind="unwind" unwindAction="returnToSearch:" id="JiB-Zi-WQ4"/>
@@ -335,11 +334,11 @@
         </scene>
     </scenes>
     <resources>
-        <image name="Cancel" width="32" height="32"/>
-        <image name="Location Pin" width="32" height="32"/>
-        <image name="Open Directions" width="30" height="30"/>
-        <image name="Route End" width="30" height="30"/>
-        <image name="Route Start" width="30" height="30"/>
-        <image name="Sedan" width="24" height="24"/>
+        <image name="Cancel" width="64" height="64"/>
+        <image name="Location Pin" width="64" height="64"/>
+        <image name="Open Directions" width="60" height="60"/>
+        <image name="Route End" width="60" height="60"/>
+        <image name="Route Start" width="60" height="60"/>
+        <image name="Sedan" width="48" height="48"/>
     </resources>
 </document>

--- a/maps-app-ios/UI/Feedback View/Feedback.storyboard
+++ b/maps-app-ios/UI/Feedback View/Feedback.storyboard
@@ -73,7 +73,8 @@
                             <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="Address or Place" translatesAutoresizingMaskIntoConstraints="NO" id="O7t-Dj-Ug0">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="56" id="SmJ-u4-nHc"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" identifier="ios10SearchbarHeight" id="QbO-WJ-dQW"/>
+                                    <constraint firstAttribute="height" priority="999" constant="56" identifier="ios11SearchbarHeight" id="SmJ-u4-nHc"/>
                                 </constraints>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="search" enablesReturnKeyAutomatically="YES" textContentType="location"/>
                                 <connections>


### PR DESCRIPTION
I couldn't work out how to negate the `if #available` statement, so this is a bit of a hokey use of `guard`, but it definitely works.