### PR TITLE
Removes the need for deactivating constraint conditionally for ios version

### DIFF
--- a/maps-app-ios/UI/Feedback View/Feedback Panels/SearchViewController.swift
+++ b/maps-app-ios/UI/Feedback View/Feedback Panels/SearchViewController.swift
@@ -18,15 +18,6 @@ class SearchViewController : UIViewController, UISearchBarDelegate {
     
     @IBOutlet weak var searchBar: UISearchBar!
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        guard #available(iOS 11, *) else {
-            searchBar.constraints.filter({ $0.identifier == "ios11SearchbarHeight" }).first?.isActive = false
-            return
-        }
-    }
-    
     lazy var suggestDebouncer:Debouncer = {
         let debouncer = Debouncer(delay: 0.1) {
             defer {

--- a/maps-app-ios/UI/Feedback View/Feedback.storyboard
+++ b/maps-app-ios/UI/Feedback View/Feedback.storyboard
@@ -70,12 +70,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="Address or Place" translatesAutoresizingMaskIntoConstraints="NO" id="O7t-Dj-Ug0">
+                            <searchBar contentMode="redraw" verticalCompressionResistancePriority="1000" searchBarStyle="minimal" placeholder="Address or Place" translatesAutoresizingMaskIntoConstraints="NO" id="O7t-Dj-Ug0">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" identifier="ios10SearchbarHeight" id="QbO-WJ-dQW"/>
-                                    <constraint firstAttribute="height" priority="999" constant="56" identifier="ios11SearchbarHeight" id="SmJ-u4-nHc"/>
-                                </constraints>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="search" enablesReturnKeyAutomatically="YES" textContentType="location"/>
                                 <connections>
                                     <outlet property="delegate" destination="Wma-xI-VYV" id="ZlC-BY-yvZ"/>


### PR DESCRIPTION
I re-examined the need to conditionally deactivate a constraint depending on iOS version in favor of a fully IB driven solution.

By setting the `UISearchBar`'s content compression resistance priority to 1000 (required) what the search bar is saying is "hey superview, you can't hug me down to the size you want me to be, you must respect my **intrinsic content size**"

Running a side by side comparison, this is the result.

<img width="790" alt="screen shot 2018-10-18 at 12 13 12 pm" src="https://user-images.githubusercontent.com/33433113/47178770-0a715f00-d2d1-11e8-9cd3-e76a957a2abb.png">
