### PR TITLE
Build Number Run Script & SDK 100.4

### DIFF
--- a/maps-app-ios.xcodeproj/project.pbxproj
+++ b/maps-app-ios.xcodeproj/project.pbxproj
@@ -659,6 +659,7 @@
 				D96A774D1E8594BF00F441D3 /* Sources */,
 				D96A774E1E8594BF00F441D3 /* Frameworks */,
 				D96A774F1E8594BF00F441D3 /* Resources */,
+				94FC1480218B676D00B85C9C /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -796,6 +797,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		94FC1480218B676D00B85C9C /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ -e $HOME/.runtime-example-apps/xcode-run-scripts/arcgis-build-number-run-script.sh ]; then\n$HOME/.runtime-example-apps/xcode-run-scripts/arcgis-build-number-run-script.sh -p ios -o $PROJECT_DIR\nelse\necho \"Cannot update ArcGIS build number.\"\nfi\n\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		D96A774D1E8594BF00F441D3 /* Sources */ = {

--- a/sdk_build
+++ b/sdk_build
@@ -1,2 +1,2 @@
 # Note: This build number is used for Esri internal development purposes and can be ignored.
-1962
+2207


### PR DESCRIPTION
Introduces `arcgis-build-number-run-script.sh` and confirms the app builds successfully with 100.4.