### PR TITLE
Update version number and add Release note.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,7 @@
+# Release 1.0.6
+
+- Certification for the 100.9.0 release of the ArcGIS Runtime SDK for iOS.
+
 # Release 1.0.5
 
 - Adds support for all screen sizes per Apple's new App Store requirements detailed here: [Building Adaptive User Interfaces for iPhone and iPad](https://developer.apple.com/news/?id=01132020b).

--- a/maps-app-ios.xcodeproj/project.pbxproj
+++ b/maps-app-ios.xcodeproj/project.pbxproj
@@ -947,7 +947,7 @@
 				);
 				INFOPLIST_FILE = "maps-app-ios/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgisruntime.opensourceapps.maps-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -975,7 +975,7 @@
 				);
 				INFOPLIST_FILE = "maps-app-ios/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.esri.arcgisruntime.opensourceapps.maps-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This updates v.next with the 1.0.6 Target version number in the Xcode project and adds a `RELEASE.md` entry for 1.0.6.

This is the last remaining work prior to publishing the 1.0.6 Release.