### PR TITLE
Increment deployment target from iOS 12 to 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ Learn more about ArcGIS open source apps [here](https://developers.arcgis.com/ex
 * [Xcode 11 and Swift 5](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)
 * [ArcGIS Runtime SDK for iOS](https://developers.arcgis.com/ios/latest/swift/guide/install.htm#ESRI_SECTION1_D57435A2BEBC4D29AFA3A4CAA722506A), version 100.10.
 * For directions and to browse Web Maps you will also need an ArcGIS Online Organizational account or an ArcGIS Online Developer account.
+* Device or Simulator running iOS 13.0 or later.
 
-**Note:** Starting from the 100.8 release, the *ArcGIS Runtime SDK for iOS* uses Apple's [Metal](https://developer.apple.com/metal/) framework to render maps and scenes. In order to run your app in a simulator you must be developing on **macOS Catalina**, using **Xcode 11**, and simulating **iOS 13**.
+**Note:** Starting from the 100.8 release, the ArcGIS Runtime SDK for iOS uses Apple's Metal framework to display maps and scenes. However, Xcode does not support Metal based rendering in any version of iOS simulator on macOS Mojave. If you are developing map or scene based apps in these environments, you will need test and debug them on a physical device instead of the simulator.
 
 **Note:** The 100.10 release of the ArcGIS Runtime SDK for iOS replaces the installed "fat framework" `ArcGIS.framework` with a new binary framework `ArcGIS.xcframework`.  It also changes the location of the installed framework file and removes the need for the `strip-frameworks.sh` Build Phase.  These changes have been incorporated in the lastest release of the *Maps App for iOS*.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
     - The `ArcGIS.framework` framework has been replaced with `ArcGIS.xcframework`.
     - The Build Phase which ran the `strip-frameworks.sh` shell script is no longer necessary.
 - Certification for the 100.10 release of the ArcGIS Runtime SDK for iOS.
+- Increments app and testing deployment targets to iOS 13.0, drops support for iOS 12.0.
 
 # Release 1.0.6
 

--- a/maps-app-ios.xcodeproj/project.pbxproj
+++ b/maps-app-ios.xcodeproj/project.pbxproj
@@ -934,6 +934,7 @@
 				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "maps-app-ios/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -961,6 +962,7 @@
 				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "maps-app-ios/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
This PR drops support for iOS 12 and increments the deployment target to iOS 13.
[[Related Issue]](https://github.com/ArcGIS/open-source-apps/issues/458)